### PR TITLE
Update GitHub CI

### DIFF
--- a/.github/workflows/builder-dev.yaml
+++ b/.github/workflows/builder-dev.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v4
 
       - name: Get information
         id: info
@@ -33,7 +33,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: env.BUILD_ARGS != '--test'
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -41,9 +41,10 @@ jobs:
 
       - name: Setup Node
         id: setup_node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 12
+          cache: npm
 
       - name: npm install and npm run build
         working-directory: meross_local_broker/addon_web_ui
@@ -58,7 +59,7 @@ jobs:
           echo "{dev_version}={$version}" >> "$GITHUB_OUTPUT"
           echo "::debug::Version set to $version"
       - name: Build ${{ matrix.addon }} add-on
-        uses: home-assistant/builder@2023.09.0
+        uses: home-assistant/builder@2024.03.5
         with:
           args: |
             ${{ env.BUILD_ARGS }} \

--- a/.github/workflows/builder-rc.yaml
+++ b/.github/workflows/builder-rc.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v4
 
       - name: Get information
         id: info
@@ -30,7 +30,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: env.BUILD_ARGS != '--test'
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -38,9 +38,10 @@ jobs:
 
       - name: Setup Node
         id: setup_node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 12
+          cache: npm
 
       - name: npm install and npm run build
         working-directory: meross_local_broker/addon_web_ui
@@ -55,7 +56,7 @@ jobs:
           echo "{rc_version}={$rc_version}" >> "$GITHUB_OUTPUT"
           echo "::debug::Version set to $rc_version"
       - name: Build ${{ matrix.addon }} add-on
-        uses: home-assistant/builder@2023.09.0
+        uses: home-assistant/builder@2024.03.5
         with:
           args: |
             ${{ env.BUILD_ARGS }} \

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v4
 
       - name: Get information
         id: info
@@ -33,7 +33,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: env.BUILD_ARGS != '--test'
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -41,9 +41,10 @@ jobs:
 
       - name: Setup Node
         id: setup_node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 12
+          cache: npm
 
       - name: npm install and npm run build
         working-directory: meross_local_broker/addon_web_ui
@@ -52,7 +53,7 @@ jobs:
           npm run-script build
 
       - name: Build ${{ matrix.addon }} add-on
-        uses: home-assistant/builder@2023.09.0
+        uses: home-assistant/builder@2024.03.5
         with:
           args: |
             ${{ env.BUILD_ARGS }} \

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v4
 
       - name: 🚀 Run Home Assistant Add-on Lint
-        uses: frenck/action-addon-linter@v2.13.2
+        uses: frenck/action-addon-linter@v2
         with:
           path: "./meross_local_broker"


### PR DESCRIPTION
This PR aims at doing the following
- Update version of actions, since a lot of them use deprecated features of GH Actions at their current version
- Enable NPM caching