### PR TITLE
Push timezone (Appliance.System.Time) to devices so power metering works

### DIFF
--- a/meross_local_broker/CHANGELOG.md
+++ b/meross_local_broker/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+- Push the timezone and DST rules (`Appliance.System.Time`) to devices whose reported timezone is empty or
+  different from the configured one, as the Meross cloud does on every connection. Without it, power-metering
+  plugs (e.g. mss310, mss210p) keep reporting 0 V / 0 A / 0 W and an empty consumption history (#42).
+  New optional `device_timezone` setting, defaulting to the Home Assistant timezone.
+- The agent now polls `Appliance.System.All` every 60 seconds from devices whose info is stale. Devices
+  reconnecting after a broker restart publish nothing on their own, so without this poll their online status
+  (and the timezone check above) never refreshed.
+
 ## 0.0.1-alpha46
 
 - Dropped support for armhf platform

--- a/meross_local_broker/DOCS.md
+++ b/meross_local_broker/DOCS.md
@@ -2,3 +2,14 @@
 
 This addon provides lan-local MQTT capabilities in combination with a fully home-assistant integrated web-ui. 
 
+## Configuration
+
+### Option: `device_timezone`
+
+Timezone (IANA name, e.g. `Europe/Rome`) pushed to the Meross devices together with the daylight-saving rules,
+exactly like the Meross cloud does when a device connects. Leave it empty to use the Home Assistant timezone.
+
+Devices paired to a local broker never receive a timezone, and power-metering plugs (mss310, mss210p, ...) do
+not report any electricity or consumption data until they get one. The agent checks the timezone reported by
+each device (`Appliance.System.All`, polled at startup, on device messages and every 60 seconds when stale) and
+sends `Appliance.System.Time` only when it is missing or different.

--- a/meross_local_broker/config.yaml
+++ b/meross_local_broker/config.yaml
@@ -29,7 +29,9 @@ options:
   reinit_db: false
   advertise: true
   debug_mode: false
+  device_timezone: ""
 schema:
   reinit_db: "bool"
   advertise: "bool"
   debug_mode: "bool"
+  device_timezone: "str?"

--- a/meross_local_broker/rootfs/opt/custom_broker/broker_agent.py
+++ b/meross_local_broker/rootfs/opt/custom_broker/broker_agent.py
@@ -5,9 +5,9 @@ import re
 import ssl
 import time
 import uuid
-from datetime import datetime
-from threading import RLock
-from typing import Dict, List
+from datetime import datetime, timedelta
+from threading import RLock, Thread
+from typing import Dict, List, Optional
 
 import paho.mqtt.client as mqtt
 from expiringdict import ExpiringDict
@@ -19,6 +19,7 @@ from db_helper import dbhelper
 from logger import get_logger, set_logger_level
 from model.db_models import Device
 from protocol import _build_mqtt_message
+from timezone_utils import build_time_payload, build_time_rules, needs_time_sync
 
 CLIENT_ID = 'broker_agent'
 APPLIANCE_MESSAGE_TOPICS = '/appliance/+/publish'
@@ -35,6 +36,11 @@ DISCONNECTION_TOPIC_RE = re.compile("^\$SYS/client-disconnections$")
 _NAT_RE = re.compile("/_nat_/([a-zA-Z0-9\-]+)")
 _CLIENTID_RE = re.compile('^fmware:([a-zA-Z0-9]+)_[a-zA-Z0-9]+$')
 _DEVICE_UPDATE_CACHE_INTERVAL_SECONDS = 60
+# How often the agent polls Appliance.System.All from devices with stale info (devices reconnecting after a
+# broker restart publish nothing on their own, so this is what keeps their status and timezone in sync)
+_DEVICE_REFRESH_INTERVAL_SECONDS = 60
+# Minimum interval between two Appliance.System.Time pushes to the same device (avoids loops if a device refuses it)
+_TIMEZONE_SYNC_COOLDOWN_SECONDS = 600
 
 
 def parse_args():
@@ -45,6 +51,8 @@ def parse_args():
     parser.add_argument('--password', type=str, required=True, help='MQTT password')
     parser.add_argument('--debug', dest='debug', action='store_true', help='When set, prints debug messages')
     parser.add_argument('--cert-ca', required=True, type=str, help='Path to the root CA certificate path')
+    parser.add_argument('--timezone', type=str, default=None,
+                        help='IANA timezone (e.g. Europe/Rome) pushed to devices that report none. Disabled when omitted.')
     parser.set_defaults(debug=False)
     parser.set_defaults(enable_bridging=False)
     return parser.parse_args()
@@ -67,13 +75,16 @@ class Broker:
                  username: str,
                  password: str,
                  cert_ca: str,
-                 enable_bridging: bool):
+                 enable_bridging: bool,
+                 device_timezone: Optional[str] = None):
         self.hostname = hostname
         self.port = port
         self.username = username
         self.password = password
         self.cert_ca = cert_ca
         self.bridging_enabled = enable_bridging
+        self.device_timezone = self._validate_timezone(device_timezone)
+        self._timezone_sync_attempts = {}
         self.c = mqtt.Client(client_id="broker", clean_session=True, protocol=mqtt.MQTTv311, transport="tcp")
         self.c.username_pw_set(username=self.username, password=self.password)
 
@@ -140,6 +151,30 @@ class Broker:
                                               dev_key=device.owner_user.mqtt_key)
         self.c.publish(topic=f"/appliance/{device_uuid}/subscribe", payload=msg)
 
+    def refresh_stale_devices(self) -> List[str]:
+        """Issue Appliance.System.All to every known device whose info is missing or older than the cache interval."""
+        now = datetime.now()
+        refreshed = []
+        for device in dbhelper.get_all_devices():
+            last_update_ts = self._devices_sys_info_timestamp.get(device.uuid)
+            if last_update_ts is None or (now - last_update_ts).total_seconds() > _DEVICE_UPDATE_CACHE_INTERVAL_SECONDS:
+                self._issue_device_get_all(device.uuid)
+                refreshed.append(device.uuid)
+        return refreshed
+
+    def start_periodic_refresh(self, interval_seconds: int = _DEVICE_REFRESH_INTERVAL_SECONDS) -> Thread:
+        def _loop():
+            while True:
+                time.sleep(interval_seconds)
+                try:
+                    self.refresh_stale_devices()
+                except Exception:
+                    l.exception("Periodic device refresh failed")
+
+        thread = Thread(target=_loop, name="device-refresh", daemon=True)
+        thread.start()
+        return thread
+
     def _handle_device_publication(self, device_uuid: str, topic: str, payload: dict):
         # If the message comes from a known device, update its online status
         dbhelper.update_device_status(device_uuid=device_uuid, status=OnlineStatus.ONLINE)
@@ -185,6 +220,41 @@ class Broker:
             self._forward_message_to_remote(bridge_uuid=device_uuid, topic=topic,
                                             payload=json.dumps(payload).encode("utf8"))
 
+    @staticmethod
+    def _validate_timezone(tz_name: Optional[str]) -> Optional[str]:
+        if not tz_name:
+            l.info("No device timezone configured: devices will not receive Appliance.System.Time")
+            return None
+        try:
+            build_time_rules(tz_name, start_ts=int(time.time()), years=1)
+        except ValueError:
+            l.error("Unknown timezone '%s': device time sync disabled", tz_name)
+            return None
+        return tz_name
+
+    def _sync_device_timezone(self, device_uuid: str, device_time: Optional[dict], dev_key: str) -> bool:
+        """Push the configured timezone (with DST rules) to a device reporting a missing/different one.
+
+        The Meross cloud does this on every connection; power-metering devices keep reporting zero
+        electricity/consumption values until they receive it. Returns True when a message was published.
+        """
+        if not needs_time_sync(device_time, self.device_timezone):
+            return False
+        now = time.time()
+        last_attempt = self._timezone_sync_attempts.get(device_uuid)
+        if last_attempt is not None and now - last_attempt < _TIMEZONE_SYNC_COOLDOWN_SECONDS:
+            l.debug("Timezone sync for device %s attempted recently, skipping", device_uuid)
+            return False
+        reported = (device_time or {}).get('timezone')
+        l.info("Device %s reports timezone %r, pushing %s", device_uuid, reported, self.device_timezone)
+        msg, _ = _build_mqtt_message(method="SET",
+                                              namespace="Appliance.System.Time",
+                                              payload=build_time_payload(self.device_timezone, now_ts=int(now)),
+                                              dev_key=dev_key)
+        self.c.publish(topic=f"/appliance/{device_uuid}/subscribe", payload=msg)
+        self._timezone_sync_attempts[device_uuid] = now
+        return True
+
     def _handle_message_to_agent(self, topic: str, payload: dict) -> None:
         # Try to guess the channels from the system_all payload
         namespace = payload.get('header', {}).get('namespace', None)
@@ -205,7 +275,7 @@ class Broker:
             # Update device info
             hardware = system.get('hardware')
             firmware = system.get('firmware')
-            time = system.get('time')
+            device_time = system.get('time')
             online = system.get('online')
             device = dbhelper.get_device_by_uuid(device_uuid=appliance_uuid)
             device.device_type = hardware.get('type')
@@ -216,6 +286,9 @@ class Broker:
             device.online_status = OnlineStatus(online.get('status'))
             device.local_ip = firmware.get('innerIp')
             dbhelper.update_device(device)
+
+            # Like the Meross cloud, make sure the device knows its timezone (needed for power metering)
+            self._sync_device_timezone(appliance_uuid, device_time, device.owner_user.mqtt_key)
 
             digest = payload.get('payload', {}).get('all', {}).get('digest', None)
             if digest is None:
@@ -255,6 +328,10 @@ class Broker:
 
             if self.bridging_enabled:
                 self._get_or_create_bridge(device_uuid=device.uuid)
+
+        elif namespace == 'Appliance.System.Time' and method == 'SETACK':
+            match = APPLIANCE_PUBLISH_TOPIC_RE.fullmatch(from_appliance or '')
+            l.info("Device %s acknowledged the timezone update", match.group(1) if match else from_appliance)
 
     def _handle_device_disconnected(self, payload: dict) -> None:
         if payload.get("event") != "disconnect":
@@ -433,7 +510,9 @@ def main():
                username=args.username,
                password=args.password,
                cert_ca=args.cert_ca,
-               enable_bridging=enable_meross_bridge)
+               enable_bridging=enable_meross_bridge,
+               device_timezone=args.timezone)
+    b.start_periodic_refresh()
 
     reconnect_interval = 10  # [seconds]
     while True:
@@ -441,7 +520,6 @@ def main():
             b.setup()
 
             while True:
-                # Every 60 seconds, issue a full device discovery
                 b.c.loop(timeout=60, max_packets=-1)
                 b.c.loop_forever()
 

--- a/meross_local_broker/rootfs/opt/custom_broker/requirements.txt
+++ b/meross_local_broker/rootfs/opt/custom_broker/requirements.txt
@@ -8,3 +8,4 @@ expiringdict==1.2.1
 dbus-python==1.2.18
 packaging
 debugpy
+backports.zoneinfo==0.2.1; python_version < "3.9"

--- a/meross_local_broker/rootfs/opt/custom_broker/test_broker_agent_timezone.py
+++ b/meross_local_broker/rootfs/opt/custom_broker/test_broker_agent_timezone.py
@@ -1,0 +1,172 @@
+"""Tests for the device timezone sync performed by the broker agent.
+
+Run with: python3 -m unittest test_broker_agent_timezone
+(requires the agent runtime dependencies: paho-mqtt, expiringdict, SQLAlchemy, meross_iot)
+"""
+import json
+import time
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import broker_agent
+
+DEVICE_UUID = "2310184977069551370248e1e9de3638"
+DEVICE_KEY = "7b9ebd3edc1f13c6cb3f0d70d4ce066f"
+
+
+class FakeMqttClient:
+    def __init__(self):
+        self.published = []
+
+    def publish(self, topic, payload):
+        self.published.append((topic, json.loads(payload)))
+
+
+class FakeDbHelper:
+    """Just enough of DbHelper for _handle_message_to_agent on a plain plug (no hub)."""
+
+    def __init__(self):
+        self.device = SimpleNamespace(uuid=DEVICE_UUID, owner_user=SimpleNamespace(mqtt_key=DEVICE_KEY),
+                                      child_subdevices=[])
+
+    def get_device_by_uuid(self, device_uuid):
+        return self.device
+
+    def get_all_devices(self):
+        return [self.device]
+
+    def update_device(self, device):
+        return device
+
+    def update_device_channel(self, device_uuid, channel_id):
+        return None
+
+
+def make_broker(device_timezone):
+    broker = broker_agent.Broker(hostname="localhost", port=2001, username="u", password="p", cert_ca=None,
+                                 enable_bridging=False, device_timezone=device_timezone)
+    broker.c = FakeMqttClient()
+    return broker
+
+
+def time_set_messages(broker):
+    return [(topic, msg) for topic, msg in broker.c.published
+            if msg["header"]["namespace"] == "Appliance.System.Time" and msg["header"]["method"] == "SET"]
+
+
+def system_all_gets(broker):
+    return [(topic, msg) for topic, msg in broker.c.published
+            if msg["header"]["namespace"] == "Appliance.System.All" and msg["header"]["method"] == "GET"]
+
+
+def system_all_getack(timezone):
+    return {
+        "header": {"namespace": "Appliance.System.All", "method": "GETACK",
+                   "from": "/appliance/%s/publish" % DEVICE_UUID},
+        "payload": {"all": {
+            "system": {
+                "hardware": {"type": "mss210p", "subType": "un", "version": "7.0.0"},
+                "firmware": {"version": "7.3.3", "server": "homeassistant.local", "port": 2001, "innerIp": "10.0.0.5"},
+                "time": {"timestamp": 1788556880, "timezone": timezone, "timeRule": []},
+                "online": {"status": 1},
+            },
+            "digest": {"togglex": [{"channel": 0, "onoff": 1}]},
+        }},
+    }
+
+
+class SyncDeviceTimezoneTest(unittest.TestCase):
+    def test_publishes_time_set_when_device_has_no_timezone(self):
+        broker = make_broker("Europe/Rome")
+        published = broker._sync_device_timezone(DEVICE_UUID, {"timezone": "", "timeRule": []}, DEVICE_KEY)
+        self.assertTrue(published)
+        topic, msg = time_set_messages(broker)[0]
+        self.assertEqual(topic, "/appliance/%s/subscribe" % DEVICE_UUID)
+        self.assertEqual(msg["header"]["from"], "/_agent")
+        self.assertEqual(msg["payload"]["time"]["timezone"], "Europe/Rome")
+        self.assertGreater(len(msg["payload"]["time"]["timeRule"]), 0)
+        self.assertAlmostEqual(msg["payload"]["time"]["timestamp"], time.time(), delta=5)
+
+    def test_skips_when_device_timezone_matches(self):
+        broker = make_broker("Europe/Rome")
+        self.assertFalse(broker._sync_device_timezone(DEVICE_UUID, {"timezone": "Europe/Rome"}, DEVICE_KEY))
+        self.assertEqual(time_set_messages(broker), [])
+
+    def test_skips_when_no_timezone_configured(self):
+        broker = make_broker(None)
+        self.assertFalse(broker._sync_device_timezone(DEVICE_UUID, {"timezone": ""}, DEVICE_KEY))
+        self.assertEqual(time_set_messages(broker), [])
+
+    def test_does_not_repeat_within_cooldown(self):
+        broker = make_broker("Europe/Rome")
+        broker._sync_device_timezone(DEVICE_UUID, {"timezone": ""}, DEVICE_KEY)
+        broker._sync_device_timezone(DEVICE_UUID, {"timezone": ""}, DEVICE_KEY)
+        self.assertEqual(len(time_set_messages(broker)), 1)
+
+    def test_retries_after_cooldown(self):
+        broker = make_broker("Europe/Rome")
+        broker._sync_device_timezone(DEVICE_UUID, {"timezone": ""}, DEVICE_KEY)
+        broker._timezone_sync_attempts[DEVICE_UUID] -= broker_agent._TIMEZONE_SYNC_COOLDOWN_SECONDS + 1
+        broker._sync_device_timezone(DEVICE_UUID, {"timezone": ""}, DEVICE_KEY)
+        self.assertEqual(len(time_set_messages(broker)), 2)
+
+    def test_invalid_configured_timezone_disables_sync(self):
+        broker = make_broker("Mars/Olympus_Mons")
+        self.assertIsNone(broker.device_timezone)
+        self.assertFalse(broker._sync_device_timezone(DEVICE_UUID, {"timezone": ""}, DEVICE_KEY))
+
+
+class PeriodicRefreshTest(unittest.TestCase):
+    """Devices reconnecting after a broker restart publish nothing, so the agent must poll System.All periodically."""
+
+    def test_refreshes_device_never_seen(self):
+        broker = make_broker("Europe/Rome")
+        with mock.patch.object(broker_agent, "dbhelper", FakeDbHelper()):
+            refreshed = broker.refresh_stale_devices()
+        self.assertEqual(refreshed, [DEVICE_UUID])
+        topic, msg = system_all_gets(broker)[0]
+        self.assertEqual(topic, "/appliance/%s/subscribe" % DEVICE_UUID)
+        self.assertEqual(msg["header"]["from"], "/_agent")
+
+    def test_skips_device_with_fresh_info(self):
+        broker = make_broker("Europe/Rome")
+        broker._devices_sys_info_timestamp[DEVICE_UUID] = broker_agent.datetime.now()
+        with mock.patch.object(broker_agent, "dbhelper", FakeDbHelper()):
+            self.assertEqual(broker.refresh_stale_devices(), [])
+        self.assertEqual(system_all_gets(broker), [])
+
+    def test_refreshes_device_with_stale_info(self):
+        broker = make_broker("Europe/Rome")
+        stale = broker_agent.datetime.now() - broker_agent.timedelta(
+            seconds=broker_agent._DEVICE_UPDATE_CACHE_INTERVAL_SECONDS + 1)
+        broker._devices_sys_info_timestamp[DEVICE_UUID] = stale
+        with mock.patch.object(broker_agent, "dbhelper", FakeDbHelper()):
+            self.assertEqual(broker.refresh_stale_devices(), [DEVICE_UUID])
+        self.assertEqual(len(system_all_gets(broker)), 1)
+
+
+class AgentMessageHandlingTest(unittest.TestCase):
+    def test_system_all_getack_without_timezone_triggers_sync(self):
+        broker = make_broker("Europe/Rome")
+        with mock.patch.object(broker_agent, "dbhelper", FakeDbHelper()):
+            broker._handle_message_to_agent("/_agent", system_all_getack(timezone=""))
+        self.assertEqual(len(time_set_messages(broker)), 1)
+
+    def test_system_all_getack_with_matching_timezone_does_not_sync(self):
+        broker = make_broker("Europe/Rome")
+        with mock.patch.object(broker_agent, "dbhelper", FakeDbHelper()):
+            broker._handle_message_to_agent("/_agent", system_all_getack(timezone="Europe/Rome"))
+        self.assertEqual(time_set_messages(broker), [])
+
+    def test_time_setack_is_accepted_without_publishing(self):
+        broker = make_broker("Europe/Rome")
+        setack = {"header": {"namespace": "Appliance.System.Time", "method": "SETACK",
+                             "from": "/appliance/%s/publish" % DEVICE_UUID}, "payload": {}}
+        with mock.patch.object(broker_agent, "dbhelper", FakeDbHelper()):
+            broker._handle_message_to_agent("/_agent", setack)
+        self.assertEqual(broker.c.published, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/meross_local_broker/rootfs/opt/custom_broker/test_timezone_utils.py
+++ b/meross_local_broker/rootfs/opt/custom_broker/test_timezone_utils.py
@@ -1,0 +1,70 @@
+"""Unit tests for timezone_utils (pure functions, no broker needed).
+
+Run with: python3 -m unittest test_timezone_utils
+"""
+import unittest
+
+from timezone_utils import build_time_rules, build_time_payload, needs_time_sync
+
+# Independent oracle (not computed with the code under test):
+# Europe/Rome switches to CEST on 2026-03-29 01:00 UTC and back to CET on 2026-10-25 01:00 UTC.
+ROME_2026_DST_START = 1774746000
+ROME_2026_DST_END = 1792890000
+JAN_1_2026 = 1767225600  # 2026-01-01 00:00 UTC
+
+
+class BuildTimeRulesTest(unittest.TestCase):
+    def test_first_rule_is_next_dst_start_with_offset_and_dst_flag(self):
+        rules = build_time_rules("Europe/Rome", start_ts=JAN_1_2026, years=1)
+        self.assertEqual(rules[0], [ROME_2026_DST_START, 7200, 1])
+
+    def test_second_rule_is_dst_end_back_to_standard_time(self):
+        rules = build_time_rules("Europe/Rome", start_ts=JAN_1_2026, years=1)
+        self.assertEqual(rules[1], [ROME_2026_DST_END, 3600, 0])
+
+    def test_two_transitions_per_year_over_requested_horizon(self):
+        rules = build_time_rules("Europe/Rome", start_ts=JAN_1_2026, years=3)
+        self.assertEqual(len(rules), 6)
+        self.assertEqual(rules, sorted(rules))
+
+    def test_only_transitions_after_start_are_returned(self):
+        after_dst_start = ROME_2026_DST_START + 3600
+        rules = build_time_rules("Europe/Rome", start_ts=after_dst_start, years=1)
+        self.assertEqual(rules[0], [ROME_2026_DST_END, 3600, 0])
+
+    def test_timezone_without_dst_has_no_rules(self):
+        self.assertEqual(build_time_rules("UTC", start_ts=JAN_1_2026, years=3), [])
+
+    def test_unknown_timezone_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            build_time_rules("Mars/Olympus_Mons", start_ts=JAN_1_2026, years=1)
+
+
+class BuildTimePayloadTest(unittest.TestCase):
+    def test_payload_matches_appliance_system_time_format(self):
+        payload = build_time_payload("Europe/Rome", now_ts=JAN_1_2026, years=1)
+        self.assertEqual(payload["time"]["timestamp"], JAN_1_2026)
+        self.assertEqual(payload["time"]["timezone"], "Europe/Rome")
+        self.assertEqual(payload["time"]["timeRule"][0], [ROME_2026_DST_START, 7200, 1])
+
+
+class NeedsTimeSyncTest(unittest.TestCase):
+    def test_empty_timezone_needs_sync(self):
+        self.assertTrue(needs_time_sync({"timestamp": 1, "timezone": "", "timeRule": []}, "Europe/Rome"))
+
+    def test_missing_time_section_needs_sync(self):
+        self.assertTrue(needs_time_sync(None, "Europe/Rome"))
+
+    def test_same_timezone_does_not_need_sync(self):
+        self.assertFalse(needs_time_sync({"timezone": "Europe/Rome", "timeRule": [[1, 2, 3]]}, "Europe/Rome"))
+
+    def test_different_timezone_needs_sync(self):
+        self.assertTrue(needs_time_sync({"timezone": "Europe/Zurich", "timeRule": [[1, 2, 3]]}, "Europe/Rome"))
+
+    def test_no_configured_timezone_never_syncs(self):
+        self.assertFalse(needs_time_sync({"timezone": "", "timeRule": []}, None))
+        self.assertFalse(needs_time_sync({"timezone": "", "timeRule": []}, ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/meross_local_broker/rootfs/opt/custom_broker/timezone_utils.py
+++ b/meross_local_broker/rootfs/opt/custom_broker/timezone_utils.py
@@ -1,0 +1,85 @@
+"""Helpers to build the ``Appliance.System.Time`` payload that Meross devices expect.
+
+The Meross cloud pushes the timezone (plus the daylight-saving transition table, ``timeRule``)
+to every device when it connects. Devices paired to this local broker never received it, and
+at least the power-metering firmware keeps ``Appliance.Control.Electricity`` at zero until a
+timezone is set. These functions are pure so they can be unit-tested without a broker.
+
+``timeRule`` format (as sent by the official app): a list of ``[utc_timestamp, utc_offset_seconds, is_dst]``
+entries, one per transition, in chronological order.
+"""
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional
+
+try:  # Python >= 3.9
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+except ImportError:  # pragma: no cover - Python 3.7/3.8 (add-on base image)
+    from backports.zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+DEFAULT_RULE_HORIZON_YEARS = 5
+_COARSE_STEP = timedelta(days=1)
+
+
+def _utc_offset_seconds(moment: datetime, tz) -> int:
+    return int(moment.astimezone(tz).utcoffset().total_seconds())
+
+
+def _is_dst(moment: datetime, tz) -> int:
+    return 1 if moment.astimezone(tz).dst() else 0
+
+
+def _bisect_transition(before_ts: int, after_ts: int, tz) -> int:
+    """Given two epoch seconds with different UTC offsets, return the first second of the new offset."""
+    reference = _utc_offset_seconds(datetime.fromtimestamp(before_ts, tz=timezone.utc), tz)
+    low, high = before_ts, after_ts
+    while high - low > 1:
+        middle = (low + high) // 2
+        if _utc_offset_seconds(datetime.fromtimestamp(middle, tz=timezone.utc), tz) == reference:
+            low = middle
+        else:
+            high = middle
+    return high
+
+
+def build_time_rules(tz_name: str, start_ts: int, years: int = DEFAULT_RULE_HORIZON_YEARS) -> List[List[int]]:
+    """Return the DST transitions of ``tz_name`` occurring after ``start_ts`` for the next ``years`` years."""
+    try:
+        tz = ZoneInfo(tz_name)
+    except (ZoneInfoNotFoundError, ValueError) as ex:
+        raise ValueError("Unknown timezone '%s'" % tz_name) from ex
+
+    start = datetime.fromtimestamp(start_ts, tz=timezone.utc)
+    end = start + timedelta(days=365 * years)
+    rules = []
+    previous = start
+    previous_offset = _utc_offset_seconds(previous, tz)
+    current = start
+    while current < end:
+        current = current + _COARSE_STEP
+        current_offset = _utc_offset_seconds(current, tz)
+        if current_offset != previous_offset:
+            transition_ts = _bisect_transition(int(previous.timestamp()), int(current.timestamp()), tz)
+            rules.append([transition_ts, current_offset, _is_dst(current, tz)])
+            previous_offset = current_offset
+        previous = current
+    return rules
+
+
+def build_time_payload(tz_name: str, now_ts: int, years: int = DEFAULT_RULE_HORIZON_YEARS) -> Dict:
+    """Build the payload of an ``Appliance.System.Time`` SET message."""
+    return {
+        "time": {
+            "timestamp": int(now_ts),
+            "timezone": tz_name,
+            "timeRule": build_time_rules(tz_name, start_ts=now_ts, years=years),
+        }
+    }
+
+
+def needs_time_sync(device_time: Optional[Dict], tz_name: Optional[str]) -> bool:
+    """Tell whether the ``system.time`` section reported by a device differs from the configured timezone."""
+    if not tz_name:
+        return False
+    if device_time is None:
+        return True
+    return device_time.get("timezone") != tz_name

--- a/meross_local_broker/rootfs/usr/local/bin/broker.sh
+++ b/meross_local_broker/rootfs/usr/local/bin/broker.sh
@@ -15,6 +15,19 @@ else
 fi
 
 # Generate a random password for agent user
+# Timezone pushed to devices (Appliance.System.Time). Falls back to the Home Assistant timezone (TZ env).
+DEVICE_TIMEZONE=$(get_option 'device_timezone' '')
+if [[ -z "$DEVICE_TIMEZONE" ]]; then
+  DEVICE_TIMEZONE="${TZ:-}"
+fi
+if [[ -n "$DEVICE_TIMEZONE" ]]; then
+  bashio::log.info "Devices will be kept in sync with timezone ${DEVICE_TIMEZONE}"
+  timezone_args=(--timezone "$DEVICE_TIMEZONE")
+else
+  bashio::log.warning "No timezone available (device_timezone option or TZ env): device time sync disabled"
+  timezone_args=()
+fi
+
 AGENT_USERNAME="_agent"
 AGENT_PASSWORD=$(openssl rand -base64 32)
 AGENT_PBKDF2=$(/usr/share/mosquitto/pw -p $AGENT_PASSWORD)
@@ -30,4 +43,4 @@ echo -e "user $AGENT_USERNAME\ntopic readwrite #">/etc/mosquitto/auth.acl
 bashio::log.info "Waiting MQTT server..."
 bashio::net.wait_for 2001
 
-exec python3 broker_agent.py --port 2001 --host localhost --username "$AGENT_USERNAME" --password "$AGENT_PASSWORD" --cert-ca "/data/mqtt/certs/ca.crt" $debug
+exec python3 broker_agent.py --port 2001 --host localhost --username "$AGENT_USERNAME" --password "$AGENT_PASSWORD" --cert-ca "/data/mqtt/certs/ca.crt" "${timezone_args[@]}" $debug


### PR DESCRIPTION
## Problem

Power-metering plugs paired to the local broker report **0 V / 0 A / 0 W** and an empty consumption history forever, while on/off works (#42 describes exactly this on four mss310; I hit it on an mss210p, firmware 7.3.3, for two years of Home Assistant history).

## Root cause

The Meross cloud pushes `Appliance.System.Time` (timezone + DST `timeRule` table) to every device when it connects. The local broker never did, so devices paired to it run with `"timezone": "", "timeRule": []` (visible in `Appliance.System.All`). The metering firmware does not produce electricity/consumption data until it has a timezone: on my device the readings went from all zeros to 229 V / 78 W a few seconds after a single `Appliance.System.Time` SET, with nothing else changed. Replying to the device's `ConsumptionConfig` PUSH, or querying over MQTT instead of HTTP, made no difference.

## Fix

- `timezone_utils.py`: pure helpers building the `timeRule` table (`[[utc_ts, utc_offset, is_dst], ...]`) from the IANA database. Uses `backports.zoneinfo` on the Python 3.7 base image (system tzdata is already there).
- `broker_agent.py`: when a device's `Appliance.System.All` GETACK reports an empty/different timezone, push `Appliance.System.Time` (10 minute per-device cooldown so a device refusing it cannot cause a loop); log the SETACK.
- New optional `device_timezone` add-on option; empty means "use the Home Assistant timezone" (`TZ` env passed by the Supervisor). Unknown names are rejected at startup with a clear log line.
- The agent now polls `Appliance.System.All` every 60 s from devices whose info is stale. Devices reconnecting after a broker restart publish nothing on their own, so the existing "on startup + on device publication" triggers never fired for them (this also left `online_status` stale). The stale `# Every 60 seconds, issue a full device discovery` comment in `main()` suggests this was the original intent.

## Testing

- `python3 -m unittest test_timezone_utils test_broker_agent_timezone` (24 tests) on Python 3.9 and inside the add-on container (Python 3.7 + backports.zoneinfo). DST transitions are checked against known dates (Europe/Rome 2026), the agent tests use a fake MQTT client and a fake db helper.
- End-to-end on a real installation (HA 2026.9, add-on alpha50 with the patched files copied into the container): cleared the timezone on the plug, restarted the container; 31 s after the plug reconnected the agent logged `reports timezone '' , pushing Europe/Rome`, the plug reported `Europe/Rome` with 10 rules and the correct local offset, and the HA sensors show real values.

## Notes

- Once a timezone has been set the readings survive clearing it again until the device reboots, which is why nobody ever noticed the dependency on a cloud-paired device.
- The `timeRule` format is the one the official app sends; the device applies it correctly (`localTimeOffset` in `Appliance.System.Debug` switches to 7200 for CEST).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
