### PR TITLE
Fix Flask startup by pinning compatible Werkzeug

### DIFF
--- a/meross_local_broker/Dockerfile
+++ b/meross_local_broker/Dockerfile
@@ -131,7 +131,8 @@ RUN mkdir -p /tmp/go \
 
 # Copy the requirements.txt file and install the listed packages
 COPY rootfs/opt/custom_broker/requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
+RUN pip3 install -r requirements.txt \
+  && python3 -c 'from flask import Flask; Flask(__name__)'
 
 WORKDIR /
 COPY rootfs /

--- a/meross_local_broker/rootfs/opt/custom_broker/requirements.txt
+++ b/meross_local_broker/rootfs/opt/custom_broker/requirements.txt
@@ -1,4 +1,6 @@
 Flask==2.1.0
+# Flask 2.1 imports werkzeug.urls.url_quote, removed in Werkzeug 3.
+Werkzeug==2.3.8
 SQLAlchemy==1.4.3
 paho-mqtt==1.5.1
 asyncio-mqtt==0.8.1


### PR DESCRIPTION
Fix for https://github.com/albertogeniola/ha-meross-local-broker/issues/60 By pinning the wekseug version. Also added an init check in image builds for Flask