### PR TITLE
Fix alpha52 startup with Flask and Werkzeug upgrade

### DIFF
--- a/meross_local_broker/CHANGELOG.md
+++ b/meross_local_broker/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+- Fix the alpha52 startup crash by upgrading Flask to 3.1.3, Werkzeug to 3.1.8, and Flask-CORS to 6.0.5.
+- Preserve signed form requests and explicit MQTT authentication denials with Flask 3's stricter JSON handling.
+- Check Flask imports and request handling during image builds to catch dependency incompatibilities before release.
+
 ## 0.0.1-alpha52
 - Push the timezone and DST rules (`Appliance.System.Time`) to devices whose reported timezone is empty or
   different from the configured one, as the Meross cloud does on every connection. Without it, power-metering

--- a/meross_local_broker/Dockerfile
+++ b/meross_local_broker/Dockerfile
@@ -133,10 +133,15 @@ RUN mkdir -p /tmp/go \
 COPY rootfs/opt/custom_broker/requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 
+# Catch incompatible Flask dependencies before publishing an image.
+RUN python3 -c 'from flask import Flask; app = Flask("build_check"); app.add_url_rule("/", view_func=lambda: "ok"); response = app.test_client().get("/"); assert response.status_code == 200 and response.data == b"ok", (response.status_code, response.data)'
+
 WORKDIR /
 COPY rootfs /
 COPY --chown=mosquitto:mosquitto --chmod=0755 rootfs/etc/mosquitto/certs /etc/mosquitto/
 
+# Exercise the real API against disposable data as well as the Flask import check.
+RUN cd /opt/custom_broker && python3 -m unittest test_http_api
 
 RUN mkdir -p /var/run/mdns/meross-mqtt && mkdir -p /var/run/mdns/meross-http-api
 

--- a/meross_local_broker/rootfs/opt/custom_broker/blueprints/devs.py
+++ b/meross_local_broker/rootfs/opt/custom_broker/blueprints/devs.py
@@ -47,20 +47,22 @@ def superuser_acl():
 @devs_blueprint.route('/auth', methods=['POST'])
 def device_login():
     """Endpoint called by the MQTT broker plugin to authenticate devices."""
-    content = request.json
+    # Keep broker authentication failures as explicit denials, including
+    # non-JSON requests which Flask 3 would otherwise reject with 415.
+    content = request.get_json(silent=True)
 
-    if content is None:
+    if not isinstance(content, dict):
         _LOGGER.debug("DEVICE_AUTH=> Raw message content: %s", request.data)
         _LOGGER.error(
             "DEVICE_AUTH=> Expected JSON body has not been received.")
         dbhelper.store_event(event_type=EventType.CONNECT_FAILURE, details=f"Invalid connection attempted from {str(request.remote_addr)}")
         return "ko", 403
 
-    username = request.json.get('username')
-    password = request.json.get('password')
-    topic = request.json.get('topic')
-    acc = request.json.get('acc')
-    clientid = request.json.get('clientid')
+    username = content.get('username')
+    password = content.get('password')
+    topic = content.get('topic')
+    acc = content.get('acc')
+    clientid = content.get('clientid')
 
     _LOGGER.debug("LOGIN_CHECK=> username: %s, password: %s, clientid: %s, topic: %s, acc: %s", str(
         username), str(password), str(clientid), str(topic), str(acc))

--- a/meross_local_broker/rootfs/opt/custom_broker/decorator.py
+++ b/meross_local_broker/rootfs/opt/custom_broker/decorator.py
@@ -49,9 +49,13 @@ def meross_http_api(original_function=None, login_required=True):
             # - sign: message signature
             # - timestamp
             # - nonce
-            if request.json is not None:
-                l.debug("Found input json (%s)", str(request.json))
-                j = request.json
+            # Flask 3 raises 415 when reading JSON from a form request.
+            # Meross clients support both signed JSON and form envelopes.
+            if request.is_json:
+                j = request.get_json()
+                if not isinstance(j, dict):
+                    raise BadRequestError("Missing or invalid payload")
+                l.debug("Found input json (%s)", str(j))
                 params = j.get('params')
                 signature = j.get('sign')
                 timestamp = j.get('timestamp')

--- a/meross_local_broker/rootfs/opt/custom_broker/requirements.txt
+++ b/meross_local_broker/rootfs/opt/custom_broker/requirements.txt
@@ -1,8 +1,9 @@
-Flask==2.1.0
+Flask==3.1.3
+Werkzeug==3.1.8
 SQLAlchemy==1.4.3
 paho-mqtt==1.5.1
 asyncio-mqtt==0.8.1
-flask-cors==3.0.10
+flask-cors==6.0.5
 meross_iot==0.4.7.5
 expiringdict==1.2.1
 dbus-python==1.2.18

--- a/meross_local_broker/rootfs/opt/custom_broker/test_http_api.py
+++ b/meross_local_broker/rootfs/opt/custom_broker/test_http_api.py
@@ -1,0 +1,135 @@
+"""API compatibility checks. Run with: python3 -m unittest test_http_api."""
+import base64
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+class HttpApiCompatibilityTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Rebind before importing the API, whose import initializes the database.
+        # Never open or modify the configured /data database during these tests.
+        import database
+        from sqlalchemy import create_engine
+
+        temporary = tempfile.TemporaryDirectory()
+        cls.addClassCleanup(temporary.cleanup)
+        engine = create_engine(f"sqlite:///{Path(temporary.name) / 'api.db'}")
+        cls.addClassCleanup(engine.dispose)
+        original_bind = database.db_session.session_factory.kw['bind']
+        database.db_session.remove()
+        database.db_session.configure(bind=engine)
+        cls.addClassCleanup(database.db_session.configure, bind=original_bind)
+        cls.addClassCleanup(database.db_session.remove)
+        engine_patch = patch.object(database, 'engine', engine)
+        engine_patch.start()
+        cls.addClassCleanup(engine_patch.stop)
+
+        import http_api
+        cls.app = http_api.app
+        cls.database = database
+
+    def setUp(self):
+        self.database.db_session.remove()
+        self.database.Base.metadata.drop_all(bind=self.database.engine)
+        self.database.init_db()
+        from db_helper import dbhelper
+        self.user = dbhelper.add_update_user(
+            email='test@example.com', password='test-password',
+            user_id=1, user_key='0123456789abcdef0123456789abcdef')
+        self.user_id = str(self.user.user_id)
+        self.mqtt_key = self.user.mqtt_key
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.database.db_session.remove()
+
+    @staticmethod
+    def envelope(payload):
+        from constants import _SECRET
+        params = base64.b64encode(json.dumps(payload).encode()).decode()
+        timestamp, nonce = '1788750000', 'testnonce'
+        signature = hashlib.md5(f'{_SECRET}{timestamp}{nonce}{params}'.encode()).hexdigest()
+        return dict(params=params, timestamp=timestamp, nonce=nonce, sign=signature)
+
+    def sign_in(self, form=False):
+        envelope = self.envelope(dict(email='test@example.com', password='test-password'))
+        kwargs = {'data': envelope} if form else {'json': envelope}
+        return self.client.post('/v1/Auth/signIn', **kwargs)
+
+    def test_signed_json_and_form_login_and_authenticated_request(self):
+        for form in (False, True):
+            with self.subTest(form=form):
+                response = self.sign_in(form)
+                self.assertEqual(response.status_code, 200)
+                result = response.get_json()
+                self.assertEqual(result['apiStatus'], 0)
+                self.assertEqual(result['data']['userid'], self.user_id)
+                response = self.client.post(
+                    '/v1/Device/devList', json=self.envelope({}),
+                    headers={'Authorization': f"Basic {result['data']['token']}"})
+                self.assertEqual(response.get_json(), {'apiStatus': 0, 'info': None, 'data': []})
+
+    def test_invalid_signature_returns_meross_error(self):
+        envelope = self.envelope({})
+        envelope['sign'] = 'invalid'
+        response = self.client.post('/v1/Auth/signIn', data=envelope)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()['info'], 'Key verification failed')
+
+    def test_non_object_json_returns_bad_request(self):
+        response = self.client.post('/v1/Auth/signIn', json=[])
+        self.assertEqual(response.status_code, 400)
+
+    def test_missing_token_returns_meross_token_error(self):
+        from meross_iot.http_api import ErrorCodes
+        response = self.client.post('/v1/Device/devList', json=self.envelope({}))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['apiStatus'], ErrorCodes.CODE_TOKEN_ERROR.value)
+
+    def test_mqtt_app_auth_accepts_valid_and_denies_invalid_password(self):
+        password = hashlib.md5(f'{self.user_id}{self.mqtt_key}'.encode()).hexdigest()
+        for supplied, status, body in ((password, 200, b'ok'), ('wrong', 403, b'ko')):
+            with self.subTest(status=status):
+                response = self.client.post('/_devs_/auth', json={
+                    'username': self.user_id, 'password': supplied, 'clientid': 'app:test'})
+                self.assertEqual((response.status_code, response.data), (status, body))
+
+    def test_invalid_mqtt_json_is_denied(self):
+        for kwargs in ({'data': 'not json'}, {'json': []},
+                       {'data': '{', 'content_type': 'application/json'}):
+            with self.subTest(kwargs=kwargs):
+                response = self.client.post('/_devs_/auth', **kwargs)
+                self.assertEqual((response.status_code, response.data), (403, b'ko'))
+
+    def test_mqtt_acl_json(self):
+        response = self.client.post('/_devs_/acl', json={
+            'username': self.user_id, 'topic': '/appliance/test/publish',
+            'acc': 2, 'clientid': 'app:test'})
+        self.assertEqual((response.status_code, response.data), (200, b'ok'))
+
+    def test_admin_json_and_cors_preflight(self):
+        response = self.client.get('/_admin_/devices', headers={'Origin': 'http://localhost'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), [])
+        self.assertEqual(response.headers['Access-Control-Allow-Origin'], 'http://localhost')
+        response = self.client.options('/v1/Auth/signIn', headers={
+            'Origin': 'http://localhost', 'Access-Control-Request-Method': 'POST',
+            'Access-Control-Request-Headers': 'Content-Type'})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('POST', response.headers['Access-Control-Allow-Methods'])
+        self.assertIn('Content-Type', response.headers['Access-Control-Allow-Headers'])
+
+    def test_database_reinitialization_preserves_account(self):
+        self.database.db_session.remove()
+        self.database.engine.dispose()
+        self.database.init_db()
+        self.assertEqual(self.sign_in().get_json()['apiStatus'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #60. The alpha52 image fails to start because the pinned Flask 2.1.0 is incompatible with the Werkzeug version that pip now resolves for it.

- Upgrade Flask to 3.1.3, pin Werkzeug to 3.1.8, and upgrade flask-cors to 6.0.5.
- Adapt the API to Flask 3's stricter JSON handling:
  - `meross_http_api` decorator: only read JSON when `request.is_json`, so signed form requests from Meross clients keep working instead of failing with 415. Non-object JSON payloads now return a 400 instead of crashing.
  - `/_devs_/auth` (MQTT broker auth hook): use `get_json(silent=True)` so malformed or non-JSON requests are still answered with an explicit `403 ko` denial rather than a 415.
- Add `test_http_api.py`, which exercises sign-in (JSON and form envelopes), an authenticated `devList` call, invalid signature handling, non-object JSON payloads, missing token handling, and the broker auth endpoint against a temporary SQLite database.
- Run a Flask import/request smoke check and the new test module during the Docker build so dependency incompatibilities fail the image build instead of the add-on at startup.
- Add an Unreleased entry to the changelog.

## Test plan

- [x] `python3 -m unittest test_http_api` passes inside the built image (runs as a Dockerfile step).
- [ ] Install the add-on built from this branch on a Home Assistant instance affected by #60 and confirm it starts and devices reconnect.

## Testing on Home Assistant OS

  1. Create a backup containing the existing Meross Local Broker add-on.
  2. Clone this branch:

     ```sh
     git clone --branch fix/flask-startup \
       https://github.com/Yety/ha-meross-local-broker.git

  3. Build the web UI using Node.js 12:

     cd ha-meross-local-broker/meross_local_broker/addon_web_ui
     npm install
     npm run build

  4. Edit meross_local_broker/config.yaml:
      - Remove or comment out the image: line so Supervisor builds the
        source locally.

      - Give the test add-on a distinct name.
      - Optionally give it a distinct slug, such as
        meross_local_broker_fixed, if it should be installed alongside
        the released add-on.

  5. Copy the complete meross_local_broker directory into /addons on
     Home Assistant OS using Samba or SSH.

  6. Refresh the add-on store and install the add-on under Local add-ons.
  7. Copy the original add-on's configuration and network port mappings.
  8. Disable the original add-on's watchdog and start-on-boot setting, then
     stop it before starting the local version.

  ## Testing with existing add-on data

  A local add-on with a different slug receives a separate /data
  directory. Its database and MQTT certificates must therefore be copied
  from the original add-on.

  This requires HAOS host access because the regular Terminal & SSH add-on
  does not expose Docker or the Supervisor data directories.

  1. Start the local add-on once so Supervisor creates its data directory.
  2. Find the old and new container names:

     docker ps -a --format 'table {{.Names}}\t{{.Status}}' | grep -i meross

  3. Find each add-on's persistent data directory:

     docker inspect OLD_CONTAINER \
       --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Source}}{{end}}{{end}}'

     docker inspect NEW_CONTAINER \
       --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Source}}{{end}}{{end}}'

  4. Stop both add-ons. Ensure the local add-on has reinit_db: false;
     otherwise it will delete the copied database during startup.

  5. Use the original add-on image to copy the data. Replace the two paths
     with the values returned by docker inspect:

     old_data=/mnt/data/supervisor/apps/data/OLD_SLUG
     new_data=/mnt/data/supervisor/apps/data/NEW_SLUG

     old_image=$(docker inspect OLD_CONTAINER --format '{{.Image}}')

     docker run --rm --network none --entrypoint /bin/sh \
       --mount "type=bind,src=$old_data,dst=/source,readonly" \
       --mount "type=bind,src=$new_data,dst=/target" \
       "$old_image" -c '
         set -eu

         test -f /source/database.db
         test -d /source/mqtt/certs

         backup=$(mktemp -d /target/before-restore.XXXXXX)

         if [ -f /target/database.db ]; then
           cp -a /target/database.db "$backup/"
         fi

         if [ -d /target/mqtt ]; then
           cp -a /target/mqtt "$backup/"
         fi

         cp -a /source/database.db /target/database.db
         mkdir -p /target/mqtt
         cp -a /source/mqtt/. /target/mqtt/
       '

  6. Start the local add-on and verify the copied data:

     docker exec NEW_CONTAINER sqlite3 -readonly /data/database.db \
       'SELECT user_id FROM users; SELECT COUNT(*) FROM devices;'

  7. Check the add-on UI and watch for device authentication and MQTT
     traffic:

     docker exec NEW_CONTAINER sh -c \
       'tail -n 0 -f /var/log/api/current /var/log/mosquitto/current /var/log/broker/current'